### PR TITLE
解决DNS问题

### DIFF
--- a/xray/etc/confs/dns.json
+++ b/xray/etc/confs/dns.json
@@ -6,7 +6,7 @@
     },
     "servers": [
       {
-        "address": "https+local://1.1.1.1/dns-query",
+        "address": "https://1.1.1.1/dns-query",
         "domains": [
           "geosite:geolocation-!cn"
         ]


### PR DESCRIPTION
默认配置里使用local的方式连接1111 但是很不幸 部分地区1111的doh并不可用 解决办法就是去掉local使用出站处理DNS且效率更高
但是很明显如果proxy的address写一个域名就会陷入先有鸡还是先有蛋的问题(解析出站需要dns 处理dns需要出站) 只能在readme提醒用户在address写上IP 如有需要再在host or sni配置域名
一个两全的办法是仍保持本地发送dns 但是使用其他未被阻断的doh 但是我还没有找到这样的服务 因为这个服务也必须要求ip直连
踩了很久的坑总结出来的