### PR TITLE
Functional requirements: Added mihomo's metacubexd UI panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Download the module zip from [Release](https://github.com/Asterisk4Magisk/Xray4M
 
 This module does not contain binaries such as [Xray-core](https://github.com/XTLS/Xray-core), When installing, the relevant files are downloaded automatically. If your network has poor access to Github, please consider using a network proxy or choose not install core online.
 
-If your device don't have volume keys, you can create file `/sdcard/xray4magisk.setup`, first line of the file will determine the core type, `xray` for Xray, `v2ray` for V2ray, `sing-box` for Sing-box, `mihomo` for Mihomo and `hysteria2` for Hysteria2, any other content will skip core installation; second line of the file will control whether to overwrite old config files, `keep` will preserve them, otherwise will be overwritten.
+If your device don't have volume keys, you can create file `/sdcard/xray4magisk.setup`, first line of the file will determine the core type, `xray` for Xray, `v2ray` for V2ray, `sing-box` for Sing-box, `mihomo` for Mihomo and `hysteria2` for Hysteria2, any other content will skip core installation; second line of the file will control whether to overwrite old config files, `keep` will preserve them, otherwise will be overwritten. The third line of the file selects the webUI type, leave it blank for default, currently the `mihomo` UI option is supported `1` for yacd-meta, `2` for metacubexd.
 
 ## Config
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -20,7 +20,7 @@
 
 注意：这个模块不包含任何核心的二进制文件，安装时，联网下载相关文件，若您的网络访问Github速度不佳，建议在模块安装过程中开启网络代理或者选择不在线安装 Core 并在模块安装成功后手动安装 Core、配置 XrayHelper
 
-如果你的设备没有音量键，可以创建文件 `/sdcard/xray4magisk.setup`，该文件的第一行将决定在线安装的核心类型，`xray` 表示使用 Xray，`v2ray` 表示使用 V2ray，`sing-box` 表示使用 Sing-box，`mihomo` 表示使用 Mihomo，`hysteria2` 表示使用 Hysteria2，其他任意内容将跳过核心安装；该文件的第二行将决定是否覆盖旧配置文件，`keep`表示保留旧配置文件，其他内容将会覆盖配置文件。
+如果你的设备没有音量键，可以创建文件 `/sdcard/xray4magisk.setup`，该文件的第一行将决定在线安装的核心类型，`xray` 表示使用 Xray，`v2ray` 表示使用 V2ray，`sing-box` 表示使用 Sing-box，`mihomo` 表示使用 Mihomo，`hysteria2` 表示使用 Hysteria2，其他任意内容将跳过核心安装；该文件的第二行将决定是否覆盖旧配置文件，`keep`表示保留旧配置文件，其他内容将会覆盖配置文件。该文件的第三行选择webUI类型，留空则默认，目前`mihomo` UI可选填写 `1` 表示使用yacd-meta， `2` 表示使用metacubexd。
 
 ## 配置文件
 

--- a/customize.sh
+++ b/customize.sh
@@ -92,15 +92,26 @@ installCore() {
         sed -i 's/corePath: .*/corePath: \/data\/adb\/xray\/bin\/mihomo/g' ${module_path}/xrayhelper.yml
         sed -i 's/coreConfig: .*/coreConfig: \/data\/adb\/xray\/mihomoconfs\//g' ${module_path}/xrayhelper.yml
         sed -i 's/template: .*/template: \/data\/adb\/xray\/mihomoconfs\/template\.yaml/g' ${module_path}/xrayhelper.yml
-        ui_print
-        ui_print "- Please select mihomo web UI"
-        ui_print "* VOL+ = yacd-meta, VOL- = metacubexd *"
-        if $VKSEL; then
-            ui_print "- Install yacd-meta"
-            su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update yacd-meta
+        if [ "$use_param" != true ]; then
+            ui_print
+            ui_print "- Please select mihomo web UI"
+            ui_print "* VOL+ = yacd-meta, VOL- = metacubexd *"
+            if $VKSEL; then
+                ui_print "- Install yacd-meta"
+                su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update yacd-meta
+            else
+                ui_print "- Install metacubexd"
+                su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update metacubexd
+            fi
         else
-            ui_print "- Install metacubexd"
-            su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update metacubexd
+            if [ "$param_uitype" != "2" ]; then
+                ui_print "- Install yacd-meta UI"
+                su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update yacd-meta
+            else
+                ui_print "- Install metacubexd UI"
+                su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update metacubexd
+            fi
+
         fi
         ui_print "- Install mihomo core"
         su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update core
@@ -206,12 +217,19 @@ releaseConfig() {
     unzip -j -o "${ZIPFILE}" 'xray/etc/adghomeconfs/config.yaml' -d ${module_path}/adghomeconfs >&2
 }
 
+# 全局变量定义
+use_param=false
+param_core=""
+param_keep=""
+param_uitype=""
+
 installModule() {
     # Params for no value key device
     if [ -f /sdcard/xray4magisk.setup ]; then
-        local use_param=true
-        local param_core=$(sed -n 1p /sdcard/xray4magisk.setup)
-        local param_keep=$(sed -n 2p /sdcard/xray4magisk.setup)
+        use_param=true
+        param_core=$(sed -n 1p /sdcard/xray4magisk.setup)
+        param_keep=$(sed -n 2p /sdcard/xray4magisk.setup)
+        param_uitype=$(sed -n 3p /sdcard/xray4magisk.setup)
     fi
 
     # Install xrayhelper

--- a/customize.sh
+++ b/customize.sh
@@ -217,7 +217,7 @@ releaseConfig() {
     unzip -j -o "${ZIPFILE}" 'xray/etc/adghomeconfs/config.yaml' -d ${module_path}/adghomeconfs >&2
 }
 
-# 全局变量定义
+# Global parameters
 use_param=false
 param_core=""
 param_keep=""

--- a/customize.sh
+++ b/customize.sh
@@ -92,8 +92,16 @@ installCore() {
         sed -i 's/corePath: .*/corePath: \/data\/adb\/xray\/bin\/mihomo/g' ${module_path}/xrayhelper.yml
         sed -i 's/coreConfig: .*/coreConfig: \/data\/adb\/xray\/mihomoconfs\//g' ${module_path}/xrayhelper.yml
         sed -i 's/template: .*/template: \/data\/adb\/xray\/mihomoconfs\/template\.yaml/g' ${module_path}/xrayhelper.yml
-        ui_print "- Install yacd-meta"
-        su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update yacd-meta
+        ui_print
+        ui_print "- Please select mihomo web UI"
+        ui_print "* VOL+ = yacd-meta, VOL- = metacubexd *"
+        if $VKSEL; then
+            ui_print "- Install yacd-meta"
+            su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update yacd-meta
+        else
+            ui_print "- Install metacubexd"
+            su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update metacubexd
+        fi
         ui_print "- Install mihomo core"
         su -c ${module_path}/bin/xrayhelper -c ${module_path}/xrayhelper.yml update core
         ;;

--- a/xray/etc/mihomoconfs/template.yaml
+++ b/xray/etc/mihomoconfs/template.yaml
@@ -9,7 +9,7 @@ keep-alive-interval: 30
 geo-auto-update: false
 geo-update-interval: 24
 external-controller: 127.0.0.1:65532
-external-ui: /data/adb/xray/data/Yacd-meta-gh-pages
+external-ui: /data/adb/xray/data/mihomoUI
 dns:
     enable: true
     enhanced-mode: redir-host

--- a/xray/etc/mihomoconfs/template.yaml
+++ b/xray/etc/mihomoconfs/template.yaml
@@ -9,7 +9,7 @@ keep-alive-interval: 30
 geo-auto-update: false
 geo-update-interval: 24
 external-controller: 127.0.0.1:65532
-external-ui: /data/adb/xray/data/mihomoUI
+external-ui: /data/adb/xray/data/Yacd-meta-gh-pages
 dns:
     enable: true
     enhanced-mode: redir-host


### PR DESCRIPTION
Functional requirements: Add mihomo's metacubexd UI panel, the new panel looks cute~

Add installation options when using mihomo, volume key selection panel：yacd-meta OR metacubexd

Tested for no bugs,[another site](https://github.com/Asterisk4Magisk/XrayHelper/pull/37/files)

btw：
Due to the older version of the module
The mihomo configuration injection is already written in template.yaml
```yaml
external-ui: /data/adb/xray/data/Yacd-meta-gh-pages
```
In the case of a non-fresh installation, in order to avoid breaking updates, update metacubeexd continues to share the Yacd-meta-gh-pages directory of the update yacd-meta methoda方法的Yacd-meta-gh-pages目录